### PR TITLE
build: update for fpm v0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ endif()
 
 # Set Git tags for dependencies
 set(M_CLI2_TAG "ea6bbffc1c2fb0885e994d37ccf0029c99b19f24" CACHE STRING "Set git tag for M_CLI2")
-set(TOML_F_TAG "e49f5523e4ee67db6628618864504448fb8c8939" CACHE STRING "Set git tag for toml_f")
-set(FPM_TAG "v0.7.0" CACHE STRING "Set git tag for fpm")
+set(JONQUIL_TAG "05d30818bb12fb877226ce284b9a3a41b971a889" CACHE STRING "Set git tag for jonquil")
+set(FPM_TAG "v0.8.0" CACHE STRING "Set git tag for fpm")
 
 set(BIN_NAME ${CMAKE_PROJECT_NAME})
 
@@ -25,7 +25,6 @@ FetchContent_Declare(
   GIT_REPOSITORY "https://github.com/fortran-lang/fpm.git"
   SOURCE_DIR "${CMAKE_BINARY_DIR}/fpm"
 )
-
 FetchContent_MakeAvailable(fpm_src)
 
 # Download the dependencies from a git project
@@ -33,7 +32,7 @@ FetchContent_Declare(
   m_cli2_src
   GIT_REPOSITORY "https://github.com/urbanjost/M_CLI2.git"
   GIT_TAG ${M_CLI2_TAG}
-  SOURCE_DIR "${fpm_src_SOURCE_DIR}/dependencies/M_CLI2"
+  SOURCE_DIR "${CMAKE_BINARY_DIR}/dependencies/M_CLI2"
 )
 
 # Do not import any of the predefined targets from the dependencies
@@ -45,21 +44,27 @@ FetchContent_Declare(
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL YES)
 
 FetchContent_Declare(
-  toml_f_src
-  GIT_REPOSITORY "https://github.com/toml-f/toml-f.git"
-  GIT_TAG ${TOML_F_TAG}
-  SOURCE_DIR "${fpm_src_SOURCE_DIR}/dependencies/toml-f"
+  jonquil_src
+  GIT_REPOSITORY "https://github.com/toml-f/jonquil.git"
+  GIT_TAG ${JONQUIL_TAG}
+  SOURCE_DIR "${CMAKE_BINARY_DIR}/dependencies/jonquil"
 )
+FetchContent_MakeAvailable(fpm_src m_cli2_src jonquil_src)
 
-FetchContent_MakeAvailable(m_cli2_src toml_f_src)
+# Get toml-f's source dir from within jonquil's source dir
+# FetchContent_Declare is first come first serve in terms of target names
+# so we cannot download toml-f directly since it is a dependency of jonquil
+# Make custom find modules available for project
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${jonquil_src_SOURCE_DIR}/config/cmake")
+find_package("toml-f" REQUIRED)
 
 # Case 2: Set after (applies only to dependency's scope and below)
-if(IS_DIRECTORY "${toml_f_src_SOURCE_DIR}")
-  set_property(DIRECTORY ${toml_f_src_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
+if(IS_DIRECTORY "${jonquil_src_SOURCE_DIR}")
+  set_property(DIRECTORY ${jonquil_src_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
 endif()
 
 message(STATUS "M_CLI2 source dir: ${m_cli2_src_SOURCE_DIR}")
-message(STATUS "toml-f source dir: ${toml_f_src_SOURCE_DIR}")
+message(STATUS "jonquil source dir: ${jonquil_src_SOURCE_DIR}")
 message(STATUS "fpm source dir: ${fpm_src_SOURCE_DIR}")
 
 # Collect source files
@@ -68,7 +73,8 @@ file(GLOB_RECURSE
   SRC_FILES
   ${m_cli2_src_SOURCE_DIR}/src/M_CLI2*.F90
   ${m_cli2_src_SOURCE_DIR}/src/M_CLI2*.f90
-  ${toml_f_src_SOURCE_DIR}/src/*.f90
+  ${jonquil_src_SOURCE_DIR}/src/*.f90
+  ${TOML_FORTRAN_SOURCE_DIR}/src/*.f90
   ${fpm_src_SOURCE_DIR}/src/*.f90
   ${fpm_src_SOURCE_DIR}/src/*.F90
   ${fpm_src_SOURCE_DIR}/src/*.h

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,8 @@
-# Fortran Package Manager
+<p align="center">
+    <a href="https://fpm.fortran-lang.org/"><img src="https://raw.githubusercontent.com/fortran-lang/assets/main/fpm/logo/2-color-alt/png/full-color-alt.png" width="800"/></a>
+</p>
+
+# [Fortran Package Manager](https://fpm.fortran-lang.org/)
 
 Fortran Package Manager (fpm) is a package manager and build system for Fortran.
 Its key goal is to improve the user experience of Fortran programmers.
@@ -27,32 +31,44 @@ Fortran Package Manager is not to be confused with
 [Jordan Sissel's fpm](https://github.com/jordansissel/fpm), a more general,
 non-Fortran related package manager.
 
-## Getting started
+**Website: <https://fpm.fortran-lang.org/>**
 
-### Setting up fpm
+## [Download](https://fpm.fortran-lang.org/en/install/index.html)
 
-#### Binary download
+Fpm is available on many platforms and through multiple package managers, see our Documentation
+webpage for a list of **[All Supported Installations](https://fpm.fortran-lang.org/en/install/index.html)**.
+
+The easiest installation routes are shown below.
+
+### [Python PyPi](https://pypi.org/project/fpm/)
+
+Fpm is available on [PyPI](https://pypi.org/project/fpm/), and can be installed with:
+
+```sh
+pip install fpm
+```
+
+### [Binary](https://github.com/fortran-lang/fpm/releases)
 
 Binaries for the latest stable release are available [to download](https://github.com/fortran-lang/fpm/releases/latest) for Windows, MacOS, and Linux.
 
-__Note:__ On Linux and MacOS, you will need to enable executable permission before you can use the binary.
+**Note:** On Linux and MacOS, you will need to enable executable permission before you can use the binary.
 
 _e.g._ `$ chmod u+x fpm-0.6.0-linux-x86_64`
 
 The binaries at the [current tag](https://github.com/fortran-lang/fpm/releases/tag/current) are updated automatically to always provide the current git version from the default branch.
 
+### [Conda]
 
-#### [Conda]
+Fpm is available on [conda-forge], to add `conda-forge` to your channels use:
 
-Fpm is available on [conda-forge], to add conda-forge to your channels use:
-
-```
+```sh
 conda config --add channels conda-forge
 ```
 
 Fpm can be installed with:
 
-```
+```sh
 conda create -n fpm fpm
 conda activate fpm
 ```
@@ -63,51 +79,12 @@ or from [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 [Conda]: https://conda.io
 [conda-forge]: https://conda-forge.org/
 
-
-#### [MSYS2]
-
-Fpm is available as MinGW package in the MSYS2 package manager,
-which supports parallelization of the target compilation.
-To install fpm with pacman use
-
-```
-pacman -S mingw-w64-x86_64-fpm
-```
-
-Afterwards fpm will be available for usage.
-Currently `i686`, `x86_64` and `ucrt-x86_64` are supported MinGW architectures for fpm.
-For more details check the package information [here](https://packages.msys2.org/base/mingw-w64-fpm).
-
-[MSYS2]: https://www.msys2.org/
-
-
-#### [Spack]
-
-Fpm is available with spack in its develop version.
-To install fpm from spack use
-
-```
-spack install fpm
-```
-
-You can add `+openmp` to enable parallelization of the target compilation in fpm.
-To use fpm in your environment load it with
-
-```
-spack load fpm
-```
-
-For more details check the package information [here](https://spack.readthedocs.io/en/latest/package_list.html#fpm).
-
-[Spack]: https://spack.io
-
-
-#### Homebrew
+### [Homebrew](https://brew.sh/)
 
 The Fortran Package Manager (fpm) is available for the [Homebrew](https://brew.sh/) package manager via an additional tap.
 To install fpm via brew, include the new tap and install using
 
-```
+```sh
 brew tap fortran-lang/fortran
 brew install fpm
 ```
@@ -117,15 +94,11 @@ Binary distributions are available for MacOS 11 (Catalina) and 12 (Big Sur) for 
 Fpm should be available and functional after those steps.
 For more details checkout the tap [here](https://github.com/fortran-lang/homebrew-fortran).
 
-#### Github Actions
+## [Get started](https://fpm.fortran-lang.org/en/tutorial/index.html)
 
-To setup *fpm* within Github actions for automated testing, you can use the [fortran-lang/setup-fpm](https://github.com/marketplace/actions/setup-fpm) action.
+**Follow our [Quickstart Tutorial](https://fpm.fortran-lang.org/en/tutorial/hello-fpm.html) to get familiar with fpm**.
 
-#### Bootstrapping on other platforms
-
-For other platforms and architectures have a look at the [bootstrapping instructions](#bootstrapping-instructions).
-
-### Creating a new project
+### Start a new project
 
 Creating a new *fpm* project is as simple as running the command
 `fpm new project_name`. This will create a new folder in your current directory
@@ -153,9 +126,9 @@ arguments can also be passed to the executable(s) or test(s) with the option
 `-- some arguments`.
 
 See additional instructions in the [Packaging guide](PACKAGING.md) or
-the [manifest reference](manifest-reference.md).
+the [manifest reference](https://fpm.fortran-lang.org/en/spec/manifest.html).
 
-
+<!-- 
 ### Bootstrapping instructions
 
 This guide explains the process of building *fpm* on a platform for the first time.
@@ -164,7 +137,7 @@ at each release.
 
 To build manually using the single source distribution, run the following code (from within the current directory)
 
-```
+```sh
 mkdir _tmp
 curl -LJ https://github.com/fortran-lang/fpm/releases/download/current/fpm.F90 > _tmp/fpm.F90
 gfortran -J _tmp _tmp/fpm.F90 -o _tmp/fpm
@@ -174,19 +147,23 @@ rm -r _tmp
 
 To automatically bootstrap using this appoach run the install script
 
-```
+```sh
 ./install.sh
-```
+``` -->
+
+## Environmental variables
 
 The table below lists the environment variables that control `fpm`'s choice of compilers, 
 compiler flags, archiver locations, and link flags, each of which can be overridden by 
 passing `fpm` flags also shown in the table.
 
-| Environment Variable | Defines               | Overridden by  |
-| :------------------- | :-------------------- | :------------- |
-| `FPM_FC`             | Fortran compiler path | `--compiler`   |
-| `FPM_CC`             | C compiler path       | `--c-compiler` |
-| `FPM_FFLAGS`         | Fortran compiler flags| `--flag`       |
-| `FPM_CFLAGS`         | C compiler flags      | `--c-flag`     |
-| `FPM_AR`             | Archiver path         | `--archiver`   |
-| `FPM_LDFLAGS`        | Link flags            | `--link-flag`  |
+| Environment Variable | Defines               | Overridden by    |
+| :------------------- | :-------------------- | :--------------- |
+| `FPM_FC`             | Fortran compiler path | `--compiler`     |
+| `FPM_CC`             | C compiler path       | `--c-compiler`   |
+| `FPM_CXX`            | C++ compiler path     | `--cxx-compiler` |
+| `FPM_FFLAGS`         | Fortran compiler flags| `--flag`         |
+| `FPM_CFLAGS`         | C compiler flags      | `--c-flag`       |
+| `FPM_CXXFLAGS`       | C++ compiler flags    | `--cxx-flag`     |
+| `FPM_AR`             | Archiver path         | `--archiver`     |
+| `FPM_LDFLAGS`        | Link flags            | `--link-flag`    |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpm"
-version = "0.7.0"
+version = "0.8.0"
 license = { text = "MIT License" }
 authors = [{ name = "fpm maintainers" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
Updates CMakeLists.txt to fetch `jonquil` and through it `toml-f`.
This is not an ideal solution, but `FetchContent_Declare` is first come first serve hence downloading and building toml-f twice,  once inside jonquil and once inside fpm would not be possible.

@awvwgk I think this is okay for the time being but we might need to be carefull in the future.
