### PR TITLE
ci: update upload and download Action versions

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -44,9 +44,9 @@ jobs:
         run: |
           pipx run build --sdist --outdir=wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.sys.os }}
           path: |
             ./wheelhouse/*.whl
             ./wheelhouse/*.tar.gz
@@ -58,10 +58,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          pattern: python-wheels*
           path: dist
+          merge-multiple: true
 
       - name: Publish package
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
We have updated to v4 the upload and download GH Actions that bring breaking changes in the construction of named artefacts.