### PR TITLE
feat: add setuptools-scm for automatic release versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _skbuild/
 
 .coverage
 coverage.xml
+src/fpm/_version.py

--- a/README.md
+++ b/README.md
@@ -23,15 +23,14 @@ The wheels are generated for the following platforms:
    [`fpm`](https://github.com/fortran-lang/fpm.git),
    [`toml-f`](https://github.com/toml-f/toml-f.git) and
    [`M_CLI2`](https://github.com/urbanjost/M_CLI2.git)
-2. Update the version number in `pyproject.toml`
-3. Update the `docs/README.md` with the README file of the fpm project
-4. Update the paths and flags in `pyproject.toml`'s
+2. Update the `docs/README.md` with the README file of the fpm project
+3. Update the paths and flags in `pyproject.toml`'s
    `[tool.cibuildwheel.overrides.environment]` table for `FC` and `LDFLAGS`
    to match those printed by `tools/wheels/cibw_before_build_macos.sh` when
    run on a GitHub runner.
-5. Commit the changes via a pull-request to `main` and ask one of the admins
+4. Commit the changes via a pull-request to `main` and ask one of the admins
    to merge it.
-6. Admins: Issue a new release on GitHub with the same version number as
+5. Admins: Issue a new release on GitHub with the same version number as
    in `pyproject.toml` using the prefix `v` e.g. `v0.1.0`.
 
 ## Development Instructions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ requires = [
     "scikit-build>=0.16.7",
     "cmake>=3.20.0",
     "ninja",
+    "setuptools_scm>=8",
 ]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpm"
-version = "0.10.0"
 license = { text = "MIT License" }
 authors = [{ name = "fpm maintainers" }]
 requires-python = ">=3.7"
@@ -27,12 +27,15 @@ classifiers = [
     "Topic :: Software Development :: Pre-processors",
     "Topic :: Utilities",
 ]
-dynamic = ["entry-points", "scripts"]
+dynamic = ["version", "entry-points", "scripts"]
 
 [project.urls]
 homepage = "https://fpm.fortran-lang.org"
 source-code = "https://github.com/fortran-lang/fpm"
 bug-tracker = "https://github.com/fortran-lang/fpm/issues"
+
+[tool.setuptools_scm]
+write_to = "src/fpm/_version.py"
 
 [tool.cibuildwheel]
 build = "cp310-*"


### PR DESCRIPTION
The version numbers inside the CMakeLists.txt file still need to be manually updated.

- [x] Need to make sure that the versioning schemes of the wheels work without the cibuildwheel.