### PR TITLE
ci/macos

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,7 +12,7 @@ jobs:
         sys:
           - { os: windows-2019, shell: "msys2 {0}" }
           - { os: ubuntu-20.04, shell: bash }
-          - { os: macos-11, shell: bash }
+          - { os: macos-13, shell: bash }
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-environment = { CC = "clang", CXX = "clang++", FC = "gfortran-11" }
+environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,6 @@ build-verbosity = "3"
 archs = ["x86_64", "arm64"]
 environment = { CC = "clang", CXX = "clang++", FC = "gfortran-11" }
 
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_arm64"
-before-build = "bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-
-# Override the default environment variables with the cross-compiled ones
-[tool.cibuildwheel.overrides.environment]
-CC = "clang"
-CXX = "clang++"
-FC = "/opt/gfortran-darwin-arm64-cross/bin/arm64-apple-darwin20.0.0-gfortran"
-LDFLAGS = "-L/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0 -Wl,-rpath,/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0"
-
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
 environment = { CC = "gcc", CXX = "g++", FC = "gfortran" }


### PR DESCRIPTION
- **build: remove cross-compilation overrides for macos-arm**
  

- **build: use GFortran-12 for macos**
  This is the lowest version in macos; both x86 and arm
  

- **ci: switch MacOs runner to macos-13**
  