### PR TITLE
fpm v0.11.0 release

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,7 +12,7 @@ jobs:
         sys:
           - { os: windows-2019, shell: "msys2 {0}" }
           - { os: ubuntu-20.04, shell: bash }
-          - { os: macos-11, shell: bash }
+          - { os: macos-13, shell: bash }
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,12 +111,6 @@ add_executable(${BIN_NAME} ${SRC_FILES} ${fpm_src_SOURCE_DIR}/app/main.f90)
 # version preproc tag was added in fpm 0.8.2
 target_compile_definitions(${BIN_NAME} PRIVATE FPM_RELEASE_VERSION=${FPM_VERSION})
 
-# HACK: circumvent compiler's default preprocessor heuristic and enable it
-# globally. This is to circumvent sr/fpm/fpm_release.f90 erroneous lowecase
-# file extension.
-# Remove in the next fpm release
-target_compile_options(${BIN_NAME} PRIVATE "-cpp")
-
 if(OpenMP_Fortran_FOUND)
   message(STATUS "OpenMP Fortran found: Building fpm for parallel execution")
   target_link_libraries(${BIN_NAME} PUBLIC OpenMP::OpenMP_Fortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ file(GLOB_RECURSE
   ${regex_src_SOURCE_DIR}/src/*.f90
   ${shlex_src_SOURCE_DIR}/src/*.f90
   ${fpm_src_SOURCE_DIR}/src/*.f90
-  ${fpm_src_SOURCE_DIR}/src/*.F90
+  ${fpm_src_SOURCE_DIR}/src/*.F90 
   ${fpm_src_SOURCE_DIR}/src/*.h
   ${fpm_src_SOURCE_DIR}/src/*.c
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(M_CLI2_TAG "7264878cdb1baff7323cc48596d829ccfe7751b8" CACHE STRING "Set git 
 set(JONQUIL_TAG "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8" CACHE STRING "Set git tag for jonquil")
 set(REGEX_TAG "1.1.2" CACHE STRING "Set git tag for Fortran-regex")
 set(SHLEX_TAG "1.0.1" CACHE STRING "Set git tag for fortran-shlex")
-set(FPM_VERSION "0.10.1" CACHE STRING "Set fpm version e.g. 8.0.0")
+set(FPM_VERSION "0.11.0" CACHE STRING "Set fpm version e.g. 8.0.0")
 set(FPM_TAG "v${FPM_VERSION}" CACHE STRING "Set git tag for fpm, default is v${FPM_VERSION}")
 
 set(BIN_NAME ${CMAKE_PROJECT_NAME})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,12 @@ bug-tracker = "https://github.com/fortran-lang/fpm/issues"
 write_to = "src/fpm/_version.py"
 
 [tool.cibuildwheel]
-build = "cp310-*"
+build = "cp312-*"
 build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-environment = { CC = "clang", CXX = "clang++", FC = "gfortran-11" }
+environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
@@ -58,4 +58,4 @@ LDFLAGS = "-L/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/1
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
-environment = { CC = "gcc", CXX = "g++", FC = "gfortran" }
+environment = { CC = "gcc", CXX = "g++", FC = "gfortran-12" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
-environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
+environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12", MACOSX_DEPLOYMENT_TARGET = 13.0 }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
@@ -58,4 +58,4 @@ LDFLAGS = "-L/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/1
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]
-environment = { CC = "gcc", CXX = "g++", FC = "gfortran-12" }
+environment = { CC = "gcc", CXX = "g++", FC = "gfortran" }


### PR DESCRIPTION
- bump fpm to `v0.11.0`
- bump macOS compatibility to `v13.0`
- bump compiler to `gfortran-12`

This should fix #23 #24, thank you @jalvesz @gnikit.