### PR TITLE
build/update ci runners

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -12,7 +12,8 @@ jobs:
         sys:
           - { os: windows-2019, shell: "msys2 {0}" }
           - { os: ubuntu-20.04, shell: bash }
-          - { os: macos-11, shell: bash }
+          - { os: macos-14, shell: bash }
+          - { os: macos-13, shell: bash } # Intel runner
     defaults:
       run:
         shell: ${{ matrix.sys.shell }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - if: runner.os == 'Windows'
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         sys:
           - { os: windows-2022, shell: "msys2 {0}" }
-          - { os: ubuntu-20.04, shell: bash }
+          - { os: ubuntu-22.04, shell: bash }
           - { os: macos-14, shell: bash }
           - { os: macos-13, shell: bash } # Intel runner
     defaults:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         sys:
-          - { os: windows-2019, shell: "msys2 {0}" }
+          - { os: windows-2022, shell: "msys2 {0}" }
           - { os: ubuntu-20.04, shell: bash }
           - { os: macos-14, shell: bash }
           - { os: macos-13, shell: bash } # Intel runner

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _skbuild/
 .coverage
 coverage.xml
 src/fpm/_version.py
+.venv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ target_compile_definitions(${BIN_NAME} PRIVATE FPM_RELEASE_VERSION=${FPM_VERSION
 # globally. This is to circumvent sr/fpm/fpm_release.f90 erroneous lowecase
 # file extension.
 # Remove in the next fpm release
-target_compile_options(${BIN_NAME} PRIVATE "-cpp")
+target_compile_options(${BIN_NAME} PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-cpp>)
 
 if(OpenMP_Fortran_FOUND)
   message(STATUS "OpenMP Fortran found: Building fpm for parallel execution")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(M_CLI2_TAG "7264878cdb1baff7323cc48596d829ccfe7751b8" CACHE STRING "Set git 
 set(JONQUIL_TAG "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8" CACHE STRING "Set git tag for jonquil")
 set(REGEX_TAG "1.1.2" CACHE STRING "Set git tag for Fortran-regex")
 set(SHLEX_TAG "1.0.1" CACHE STRING "Set git tag for fortran-shlex")
-set(FPM_VERSION "0.10.1" CACHE STRING "Set fpm version e.g. 8.0.0")
+set(FPM_VERSION "0.10.0" CACHE STRING "Set fpm version e.g. 8.0.0")
 set(FPM_TAG "v${FPM_VERSION}" CACHE STRING "Set git tag for fpm, default is v${FPM_VERSION}")
 
 set(BIN_NAME ${CMAKE_PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(M_CLI2_TAG "7264878cdb1baff7323cc48596d829ccfe7751b8" CACHE STRING "Set git 
 set(JONQUIL_TAG "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8" CACHE STRING "Set git tag for jonquil")
 set(REGEX_TAG "1.1.2" CACHE STRING "Set git tag for Fortran-regex")
 set(SHLEX_TAG "1.0.1" CACHE STRING "Set git tag for fortran-shlex")
-set(FPM_VERSION "0.10.0" CACHE STRING "Set fpm version e.g. 8.0.0")
+set(FPM_VERSION "0.11.0" CACHE STRING "Set fpm version e.g. 8.0.0")
 set(FPM_TAG "v${FPM_VERSION}" CACHE STRING "Set git tag for fpm, default is v${FPM_VERSION}")
 
 set(BIN_NAME ${CMAKE_PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -21,16 +21,14 @@ The wheels are generated for the following platforms:
 
 1. Update the git tags and/or git commit IDs in `CMakeLists.txt` for:
    [`fpm`](https://github.com/fortran-lang/fpm.git),
-   [`toml-f`](https://github.com/toml-f/toml-f.git) and
-   [`M_CLI2`](https://github.com/urbanjost/M_CLI2.git)
+   [`jonquil`](https://github.com/toml-f/jonquil.git),
+   [`M_CLI2`](https://github.com/urbanjost/M_CLI2.git),
+   [`fortran-regex`](https://github.com/perazz/fortran-regex.git) and
+   [`fortran-shlex`](https://github.com/perazz/fortran-shlex.git).
 2. Update the `docs/README.md` with the README file of the fpm project
-3. Update the paths and flags in `pyproject.toml`'s
-   `[tool.cibuildwheel.overrides.environment]` table for `FC` and `LDFLAGS`
-   to match those printed by `tools/wheels/cibw_before_build_macos.sh` when
-   run on a GitHub runner.
-4. Commit the changes via a pull-request to `main` and ask one of the admins
+3. Commit the changes via a pull-request to `main` and ask one of the admins
    to merge it.
-5. Admins: Issue a new release on GitHub with the same version number as
+4. Admins: Issue a new release on GitHub with the same version number as
    in `pyproject.toml` using the prefix `v` e.g. `v0.1.0`.
 
 ## Development Instructions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fpm"
-license = { text = "MIT License" }
+license = "MIT"
 authors = [{ name = "fpm maintainers" }]
 requires-python = ">=3.7"
 description = "Fortran package manager"
@@ -19,7 +19,6 @@ keywords = ["fpm", "fortran", "package manager"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Fortran",
     "Topic :: Software Development :: Build Tools",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,19 +42,19 @@ build = "cp310-*"
 build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["auto"]
 environment = { CC = "clang", CXX = "clang++", FC = "gfortran-11" }
 
-[[tool.cibuildwheel.overrides]]
-select = "*-macosx_arm64"
-before-build = "bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+# [[tool.cibuildwheel.overrides]]
+# select = "*-macosx_arm64"
+# before-build = "bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
 
-# Override the default environment variables with the cross-compiled ones
-[tool.cibuildwheel.overrides.environment]
-CC = "clang"
-CXX = "clang++"
-FC = "/opt/gfortran-darwin-arm64-cross/bin/arm64-apple-darwin20.0.0-gfortran"
-LDFLAGS = "-L/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0 -Wl,-rpath,/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0"
+# # Override the default environment variables with the cross-compiled ones
+# [tool.cibuildwheel.overrides.environment]
+# CC = "clang"
+# CXX = "clang++"
+# FC = "/opt/gfortran-darwin-arm64-cross/bin/arm64-apple-darwin20.0.0-gfortran"
+# LDFLAGS = "-L/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0 -Wl,-rpath,/opt/gfortran-darwin-arm64-cross/lib/gcc/arm64-apple-darwin20.0.0/11.3.0"
 
 [tool.cibuildwheel.windows]
 archs = ["auto64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ bug-tracker = "https://github.com/fortran-lang/fpm/issues"
 write_to = "src/fpm/_version.py"
 
 [tool.cibuildwheel]
-build = "cp310-*"
+build = "cp311-*"
 build-verbosity = "3"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=67.0.0",
+    "setuptools>=80",
     "scikit-build>=0.16.7",
-    "cmake>=3.20.0",
+    "cmake>=4.1.0",
     "ninja",
     "setuptools_scm>=8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
 archs = ["auto"]
-environment = { CC = "clang", CXX = "clang++", FC = "gfortran-11" }
+environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
 
 # [[tool.cibuildwheel.overrides]]
 # select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,16 +42,16 @@ build-verbosity = "3"
 
 [tool.cibuildwheel.macos]
 archs = ["auto"]
-environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
+environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12", PATH = "/opt/homebrew/bin:/usr/local/bin:$PATH" }
 before-all = "brew install gcc@12"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"
-environment = { MACOSX_DEPLOYMENT_TARGET = "14.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "14.0", FC = "/opt/homebrew/bin/gfortran-12" }
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
-environment = { MACOSX_DEPLOYMENT_TARGET = "13.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET = "13.0", FC = "/usr/local/bin/gfortran-12" }
 
 # [[tool.cibuildwheel.overrides]]
 # select = "*-macosx_arm64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,14 @@ build-verbosity = "3"
 archs = ["auto"]
 environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
 
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+environment = { MACOSX_DEPLOYMENT_TARGET = "14.0" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+environment = { MACOSX_DEPLOYMENT_TARGET = "13.0" }
+
 # [[tool.cibuildwheel.overrides]]
 # select = "*-macosx_arm64"
 # before-build = "bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ write_to = "src/fpm/_version.py"
 
 [tool.cibuildwheel]
 build = "cp311-*"
-build-verbosity = "3"
+build-verbosity = 3
 
 [tool.cibuildwheel.macos]
 archs = ["auto"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ build-verbosity = "3"
 [tool.cibuildwheel.macos]
 archs = ["auto"]
 environment = { CC = "clang", CXX = "clang++", FC = "gfortran-12" }
+before-all = "brew install gcc@12"
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_arm64"


### PR DESCRIPTION
This PR fixes/changes the following things in the deployment repo:
- Disables cross-compilation for Arm on MacOS. Wheels are now built natively for both Intel and Arm architectures.
  - Minimum `MACOSX_DEPLOYMENT_TARGET = "13.0"`. This was forced via GCC-12 where it is the minimum requirement.
- Updates the Windows runner to Windows-2022
- Updates the Linux runner to Ubuntu-22
- Adds Guard for enabling preprocessor macros only on Fortran compilers
- Uses the modern SPDX license identifier for setuptools
- Bumps cmake and setuptools to modern versions
- Bumps fpm to v0.11.0
- Uses Python 3.11 to build wheels


## MacOS Builds
- Intel: Must be 13.0 - this is the hard minimum from GFortran libraries
- ARM64: Must be 14.0 - ARM64 support started in 11.0, but GFortran libraries require 14.0 anyway

## Compatibility Impact:

- 13.0 (Ventura, Oct 2022): Excludes Macs older than ~2.5 years
- Supported: Most Intel Macs from 2018+, all Apple Silicon Macs
- Excluded: Older Intel Macs running Monterey (12.x) or earlier